### PR TITLE
Margem no rodapé, para páginas de conteúdo

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -1,1 +1,21 @@
-.navbar-dark .navbar-nav .nav-link{color:rgba(255,255,255,.9);z-index:1000}.btn-lg{color:#fff;width:80%;text-transform:uppercase;font-size:1.5em;font-weight:600}.btn-lg:hover{color:#fff}
+.navbar-dark .navbar-nav .nav-link {
+    color: rgba(255, 255, 255, .9);
+    z-index: 1000
+}
+
+.btn-lg {
+    color: #fff;
+    width: 80%;
+    text-transform: uppercase;
+    font-size: 1.5
+    em;
+    font-weight: 600
+}
+
+.btn-lg:hover {
+    color: #fff
+}
+
+main .container {
+  margin-bottom: 40px;
+}

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -7,8 +7,7 @@
     color: #fff;
     width: 80%;
     text-transform: uppercase;
-    font-size: 1.5
-    em;
+    font-size: 1.5em;
     font-weight: 600
 }
 


### PR DESCRIPTION
Actualmente algumas páginas (Estatísticas, Sobre, Media) tem o conteúdo encostado ao rodapé do browser, o que pode dificultar a sua comprensão. Foi adicionado espaço vertical a estas páginas, não interferindo com a página do mapa.

O código fonte do CSS estava minificado, coloquei com identação mais legível para edição.